### PR TITLE
Add responsive navigation drawer

### DIFF
--- a/client/src/components/Header/Header.jsx
+++ b/client/src/components/Header/Header.jsx
@@ -1,14 +1,26 @@
-import { NavLink } from "react-router-dom";
+import { useCallback, useState } from "react";
 import { useSelector } from "../../lib/reactRedux.js";
 import {
   selectMeta,
   selectNavigation,
 } from "../../store/slices/contentSlice.js";
+import NavigationMenu from "../NavigationMenu/NavigationMenu.jsx";
+import SideDrawer from "../SideDrawer/SideDrawer.jsx";
 import styles from "./header.styles.module.scss";
 
 const Header = () => {
   const navigation = useSelector(selectNavigation);
   const meta = useSelector(selectMeta);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const drawerId = "primary-navigation-drawer";
+
+  const toggleDrawer = () => {
+    setIsDrawerOpen((prev) => !prev);
+  };
+
+  const closeDrawer = useCallback(() => {
+    setIsDrawerOpen(false);
+  }, []);
 
   return (
     <header className={styles.header}>
@@ -16,21 +28,36 @@ const Header = () => {
         <span className={styles.logo}>LuxeAura</span>
         <span className={styles.tagline}>{meta.tagline}</span>
       </div>
-      <nav className={styles.navigation} aria-label="Primary navigation">
-        {navigation.map((item) => (
-          <NavLink
-            key={item.path}
-            to={item.path}
-            className={({ isActive }) =>
-              [styles.link, isActive ? styles.active : ""]
-                .filter(Boolean)
-                .join(" ")
-            }
-          >
-            {item.label}
-          </NavLink>
-        ))}
-      </nav>
+      <div className={styles.desktopNavigation}>
+        <NavigationMenu items={navigation} variant="desktop" />
+      </div>
+      <button
+        type="button"
+        className={styles.menuToggle}
+        onClick={toggleDrawer}
+        aria-expanded={isDrawerOpen}
+        aria-controls={drawerId}
+      >
+        <span className={styles.toggleLabel}>Menu</span>
+        <span className={styles.toggleIcon} aria-hidden="true">
+          <span />
+          <span />
+          <span />
+        </span>
+      </button>
+      <SideDrawer
+        id={drawerId}
+        isOpen={isDrawerOpen}
+        onClose={closeDrawer}
+        title="Menu"
+      >
+        <NavigationMenu
+          items={navigation}
+          variant="mobile"
+          onNavigate={closeDrawer}
+          ariaLabel="Mobile navigation"
+        />
+      </SideDrawer>
     </header>
   );
 };

--- a/client/src/components/Header/header.styles.module.scss
+++ b/client/src/components/Header/header.styles.module.scss
@@ -5,15 +5,17 @@
   padding: 1.5rem 4vw;
   position: sticky;
   top: 0;
-  z-index: 10;
-  background-color: rgba(255, 255, 255, 0.85);
+  z-index: 15;
+  background-color: rgba(255, 255, 255, 0.88);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid rgba(15, 15, 16, 0.08);
+  gap: 2rem;
 }
 
 .branding {
   display: flex;
   flex-direction: column;
+  gap: 0.25rem;
 }
 
 .logo {
@@ -29,34 +31,71 @@
   color: rgba(15, 15, 16, 0.6);
 }
 
-.navigation {
-  display: flex;
-  gap: 1rem;
+.desktopNavigation {
+  margin-left: auto;
 }
 
-.link {
-  font-size: 0.95rem;
+.menuToggle {
+  display: none;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  background: #0f0f10;
+  color: #ffffff;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding-bottom: 0.25rem;
-  border-bottom: 2px solid transparent;
-  transition: border-color 0.3s ease, color 0.3s ease;
+  cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.3s ease;
 }
 
-.link:hover,
-.active {
-  color: #9c6bff;
-  border-color: #9c6bff;
+.menuToggle:hover,
+.menuToggle:focus-visible {
+  background: #1f1f20;
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.toggleLabel {
+  font-weight: 600;
+}
+
+.toggleIcon {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.25rem;
+  width: 1.25rem;
+}
+
+.toggleIcon span {
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  width: 100%;
+  transition: transform 0.3s ease;
+}
+
+@media (max-width: 960px) {
+  .desktopNavigation {
+    display: none;
+  }
+
+  .menuToggle {
+    display: inline-flex;
+  }
 }
 
 @media (max-width: 720px) {
   .header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
+    padding: 1.25rem 4vw;
   }
+}
 
-  .navigation {
-    flex-wrap: wrap;
+@media (max-width: 520px) {
+  .tagline {
+    display: none;
   }
 }

--- a/client/src/components/NavigationMenu/NavigationMenu.jsx
+++ b/client/src/components/NavigationMenu/NavigationMenu.jsx
@@ -1,0 +1,28 @@
+import { NavLink } from "react-router-dom";
+import styles from "./navigationMenu.styles.module.scss";
+
+const NavigationMenu = ({ items = [], variant = "desktop", onNavigate, ariaLabel = "Primary navigation" }) => {
+  const menuClassName = [styles.menu, styles[variant]].filter(Boolean).join(" ");
+  const linkVariantClass = styles[`${variant}Link`];
+
+  return (
+    <nav className={menuClassName} aria-label={ariaLabel}>
+      {items.map((item) => (
+        <NavLink
+          key={item.path}
+          to={item.path}
+          onClick={() => onNavigate?.()}
+          className={({ isActive }) =>
+            [styles.link, linkVariantClass, isActive ? styles.active : ""]
+              .filter(Boolean)
+              .join(" ")
+          }
+        >
+          {item.label}
+        </NavLink>
+      ))}
+    </nav>
+  );
+};
+
+export default NavigationMenu;

--- a/client/src/components/NavigationMenu/navigationMenu.styles.module.scss
+++ b/client/src/components/NavigationMenu/navigationMenu.styles.module.scss
@@ -1,0 +1,48 @@
+.menu {
+  display: flex;
+  align-items: center;
+}
+
+.desktop {
+  gap: 1.5rem;
+}
+
+.mobile {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.75rem;
+  width: 100%;
+}
+
+.link {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding-bottom: 0.25rem;
+  border-bottom: 2px solid transparent;
+  color: #0f0f10;
+  transition: color 0.3s ease, border-color 0.3s ease;
+}
+
+.desktopLink {
+  display: inline-flex;
+  align-items: center;
+}
+
+.mobileLink {
+  font-size: 1.125rem;
+  border-bottom: none;
+  padding: 0;
+  width: 100%;
+}
+
+.link:hover,
+.active {
+  color: #9c6bff;
+  border-color: #9c6bff;
+}
+
+.mobileLink:hover,
+.mobileLink:focus {
+  color: #9c6bff;
+}

--- a/client/src/components/SideDrawer/SideDrawer.jsx
+++ b/client/src/components/SideDrawer/SideDrawer.jsx
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import styles from "./sideDrawer.styles.module.scss";
+
+const joinClassNames = (...classNames) => classNames.filter(Boolean).join(" ");
+
+const SideDrawer = ({ isOpen, onClose, id, title = "Menu", children }) => {
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return undefined;
+    }
+
+    if (!isOpen) {
+      document.body.style.removeProperty("overflow");
+      return undefined;
+    }
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [isOpen]);
+
+  const handleClose = () => {
+    if (!onClose) {
+      return;
+    }
+
+    onClose();
+  };
+
+  return (
+    <>
+      <div
+        className={joinClassNames(styles.overlay, isOpen ? styles.overlayOpen : "")}
+        role="presentation"
+        onClick={handleClose}
+      />
+      <aside
+        id={id}
+        className={joinClassNames(styles.drawer, isOpen ? styles.drawerOpen : "")}
+        role="dialog"
+        aria-modal={isOpen ? "true" : "false"}
+        aria-hidden={!isOpen}
+      >
+        <div className={styles.drawerHeader}>
+          <span className={styles.drawerTitle}>{title}</span>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={handleClose}
+            aria-label="Close navigation menu"
+          >
+            <span className={styles.closeIcon} aria-hidden="true">
+              &times;
+            </span>
+          </button>
+        </div>
+        <div className={styles.drawerContent}>{children}</div>
+      </aside>
+    </>
+  );
+};
+
+export default SideDrawer;

--- a/client/src/components/SideDrawer/sideDrawer.styles.module.scss
+++ b/client/src/components/SideDrawer/sideDrawer.styles.module.scss
@@ -1,0 +1,86 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 15, 16, 0.4);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 90;
+}
+
+.overlayOpen {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(340px, 82vw);
+  background: #ffffff;
+  transform: translateX(100%);
+  transition: transform 0.35s ease;
+  z-index: 95;
+  display: flex;
+  flex-direction: column;
+  padding: 1.75rem 1.5rem;
+  box-shadow: -8px 0 24px rgba(15, 15, 16, 0.18);
+}
+
+.drawerOpen {
+  transform: translateX(0);
+}
+
+.drawerHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.drawerTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.closeButton {
+  border: none;
+  background: transparent;
+  padding: 0.25rem;
+  color: #0f0f10;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.closeButton:hover,
+.closeButton:focus-visible {
+  background-color: rgba(15, 15, 16, 0.08);
+  color: #9c6bff;
+  outline: none;
+}
+
+.closeIcon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.drawerContent {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+@media (max-width: 420px) {
+  .drawer {
+    width: min(320px, 92vw);
+    padding: 1.5rem 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable NavigationMenu and SideDrawer components to share navigation markup
- update the header with a toggleable mobile drawer and refreshed styling
- lock body scroll and polish drawer experience when the mobile menu is open

## Testing
- npm --prefix client run test

------
https://chatgpt.com/codex/tasks/task_e_68cdaf338c9c8330a1012641a167793a